### PR TITLE
Build out discord api client and message run loop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Background
+
+
+
+## Changes
+
+* 
+
+## Links
+
+* 
+
+## This PR makes me feel
+
+![]()

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode/
 .snowball.conf
-
+data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.snowball.conf.example
+++ b/.snowball.conf.example
@@ -3,9 +3,10 @@ name = snowball-bot
 log_level = INFO
 
 [discord]
-server = serverid
-channel = channelid
+application_id = 12345
+public_key=123abc
 token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNjb3JkLXNoaXQiOiJzb21lIGZ1Y2tpbmcgYXBpIHRva2VuIn0.ZNzYeAB71wLXi_YqB-fFKUQGJmrO9GCie5kcpQlMb2c
+permissions_integer = 75840
 
 [slack]
 team = teamid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:latest
 WORKDIR /root
-COPY . .
+COPY ./packages /root/packages
+COPY ./.snowball.conf .
+COPY ./main.py .
+COPY ./Pipfile .
 RUN pip install pipenv
 RUN pipenv install
 ENTRYPOINT [ "pipenv", "run", "./main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,7 @@ services:
     build:
       context: .
     image: snowball-bot:latest
+    volumes:
+      - ./data:/root/data
+      
     

--- a/main.py
+++ b/main.py
@@ -1,17 +1,24 @@
+"""main entrypoint for the bot"""
+
 #!/usr/bin/env python
+import sys
+from logging import error
+from multiprocessing import Pool
 from fire import Fire
-from packages.config.config import init
-from sys import exit
-import logging
+from packages.config.config import init, services
+from packages.services.services import clients
+from packages.errors.errors import ConfigError
 
 def Run(config:str=".snowball.conf") -> None:
     """Snowball is a bot for rolling a ball up the hill, if that ball was a number and
     rolling was posting increasing counting messages in a discord channel"""
     try:
         init(config)
-    except Exception as e:
-        logging.error(e)
-        exit(1)
+        with Pool(2) as pool:
+            pool.apply_async(lambda service: clients[service](), services.keys())
+    except ConfigError as cerr:
+        error(cerr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,11 +1,10 @@
+#!/usr/bin/env python
 """main entrypoint for the bot"""
 
-#!/usr/bin/env python
 import sys
 from logging import error
-from multiprocessing import Pool
 from fire import Fire
-from packages.config.config import init, services
+from packages.config.config import init
 from packages.services.services import clients
 from packages.errors.errors import ConfigError
 
@@ -14,12 +13,10 @@ def Run(config:str=".snowball.conf") -> None:
     rolling was posting increasing counting messages in a discord channel"""
     try:
         init(config)
-        with Pool(2) as pool:
-            pool.apply_async(lambda service: clients[service](), services.keys())
     except ConfigError as cerr:
         error(cerr)
         sys.exit(1)
-
+    clients["discord"]()
 
 if __name__ == "__main__":
     Fire(Run)

--- a/packages/config/config.py
+++ b/packages/config/config.py
@@ -1,9 +1,12 @@
 """module to handle the ingress of configuration and setup of the logger"""
 from configparser import ConfigParser
-import logging
+from logging import info
 from packages.errors.errors import ConfigError
+from .logging import init_logs
 
-services = {}
+services:dict[str, dict[str, str]] = {}
+core:dict[str, str]={}
+
 
 def init(config:str)->(None|Exception):
     """initializes the configuration for the bot"""
@@ -13,22 +16,21 @@ def init(config:str)->(None|Exception):
         parser.read_file(fp_in)
 
     name = parser.get("core", "name", fallback="snowball")
-    level = parser.get("core", "log_level", fallback="WARN").upper()
-    logging.basicConfig(
-        level=logging.getLevelNamesMapping()[level],
-        format=f"{name} [%(levelname)s] - %(message)s")
+    core["name"] = name
 
-    logging.info("configuring services")
+    level = parser.get("core", "log_level", fallback="WARN").upper()
+    init_logs(name, level)
+    info("configuring services")
     has_service = False
     if "discord" in parser.sections():
-        services["discord"] = parser["discord"]
-        logging.info("discord service configured")
+        services["discord"] = dict(parser["discord"])
+        info("discord service configured")
         has_service = True
 
     # adding for future integration
     if "slack" in parser.sections():
-        services["slack"] = parser["slack"]
-        logging.info("slack service configured")
+        services["slack"] = dict(parser["slack"])
+        info("slack service configured")
         has_service = True
 
     if not has_service:

--- a/packages/config/logging.py
+++ b/packages/config/logging.py
@@ -1,5 +1,5 @@
 """module to manage logging"""
-from logging import Formatter, StreamHandler, getLevelNamesMapping, basicConfig
+from logging import Formatter, StreamHandler, FileHandler, getLevelNamesMapping, basicConfig
 from typing import Any
 from sys import stdout
 
@@ -10,6 +10,7 @@ def init_logs(name:str, level:str)->None:
     log["formatter"] = Formatter(f"{name} [%(levelname)s] - %(message)s")
     log["level"] = getLevelNamesMapping()[level]
     log["handler"] = StreamHandler(stream=stdout)
+    f_handler = FileHandler(filename=f"{name}.log")
     log["handler"].setFormatter(log["formatter"])
     log["handler"].setLevel(log["level"])
-    basicConfig(level=log["level"], handlers=[log["handler"],])
+    basicConfig(level=log["level"], handlers=[log["handler"], f_handler])

--- a/packages/config/logging.py
+++ b/packages/config/logging.py
@@ -1,0 +1,15 @@
+"""module to manage logging"""
+from logging import Formatter, StreamHandler, getLevelNamesMapping, basicConfig
+from typing import Any
+from sys import stdout
+
+log:dict[str, Any] = {}
+
+def init_logs(name:str, level:str)->None:
+    """initialize the default logger and the global bits"""
+    log["formatter"] = Formatter(f"{name} [%(levelname)s] - %(message)s")
+    log["level"] = getLevelNamesMapping()[level]
+    log["handler"] = StreamHandler(stream=stdout)
+    log["handler"].setFormatter(log["formatter"])
+    log["handler"].setLevel(log["level"])
+    basicConfig(level=log["level"], handlers=[log["handler"],])

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -21,10 +21,12 @@ class DiscordClient(Client):
             await message.add_reaction(PartialEmoji(name='✅'))
         else:
             reset_count()
-            await message.channel.send("That wasn't the correct count, the cycle begins anew.", mention_author=True)
+            await message.channel.send(
+                "That wasn't the correct count, the cycle begins anew.", mention_author=True)
 
-async def new_client(conf:dict)->DiscordClient:
+def run()->None:
     """creates a new discord client"""
-    bot = DiscordClient(intents=Intents.all())
-    await bot.login(token=conf["token"])
-    return bot
+    bot = DiscordClient(
+        intents=Intents(
+            value=int(services["discord"]["permissions_integer"])))
+    bot.run(token=services["discord"]["token"])

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -1,7 +1,6 @@
 """module managing connecting to the discord api"""
 import logging
-from discord import Client, Message, Intents, PartialEmoji
-from packages.counting.counting import check_next_count, reset_count
+from discord import Client, Intents, Message
 from packages.config.config import services
 
 class DiscordClient(Client):
@@ -9,24 +8,26 @@ class DiscordClient(Client):
     async def on_ready(self):
         """called when the client is ready to send and recieve messages"""
         logging.info("bot started")
+        for channel in self.get_all_channels():
+            if channel.name == services["discord"]["channel"]:
+                await channel.send(
+                    "Hello from the Snowball bot, I just restarted and your last valid count was #")
+
     async def on_message(self, message:Message):
         """handle new messages in the configured channel"""
-        if message.channel != services["discord"]["channel"]:
+        if message.channel.name != services["discord"]["channel"]:
             return
 
-        if message.author == self.user:
+        if message.author.id == self.user.id:
             return
-
-        if check_next_count(message.content):
-            await message.add_reaction(PartialEmoji(name='✅'))
-        else:
-            reset_count()
-            await message.channel.send(
-                "That wasn't the correct count, the cycle begins anew.", mention_author=True)
+    
+        await message.channel.send(
+            "hello! I will respond to numbers in this channel when that feature has been added")
 
 def run()->None:
     """creates a new discord client"""
-    bot = DiscordClient(
-        intents=Intents(
-            value=int(services["discord"]["permissions_integer"])))
+    intents = Intents.default()
+    intents.message_content = True
+    intents.emojis = True
+    bot = DiscordClient(intents=intents)
     bot.run(token=services["discord"]["token"])

--- a/packages/services/services.py
+++ b/packages/services/services.py
@@ -1,6 +1,7 @@
 """module to manage main interface to the services package"""
 
-from .discord import new_client
+from .discord import run
+
 clients = {
-    "discord": new_client,
+    "discord": run,
 }


### PR DESCRIPTION
## Background

I'd like to get the discord run loop a bit more solid before dealing with the counting validation and state management, this kinda takes that on, while also adding a few prep things for the future state management.

## Changes

* Updates Dockerfile and docker-compose config to allow for data dir
* Store logging formatter/handler in accessible package var for future integrations/subloggers
* Add main bot multiprocess async run loop iteration

## Links

* [Docs on setting up discord bot](https://discordpy.readthedocs.io/en/latest/discord.html)

## This PR makes me feel

loop-y

![a gif of a toucan eating fruit loops out of a small box of cereal](https://media0.giphy.com/media/wapSaE3rNQoZa/giphy-downsized.gif?cid=6104955etshaeucenhkkags2yg4sdxbd1lcpl0kyfdu9f4jw&ep=v1_gifs_translate&rid=giphy-downsized.gif&ct=g)