### PR TITLE
Add initial counting logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:latest
+RUN apt update && apt upgrade
+RUN apt install -y dc
 WORKDIR /root
 COPY ./packages /root/packages
 COPY ./.snowball.conf .

--- a/packages/config/config.py
+++ b/packages/config/config.py
@@ -7,7 +7,6 @@ from .logging import init_logs
 services:dict[str, dict[str, str]] = {}
 core:dict[str, str]={}
 
-
 def init(config:str)->(None|Exception):
     """initializes the configuration for the bot"""
     parser = ConfigParser()
@@ -15,11 +14,12 @@ def init(config:str)->(None|Exception):
     with open(config, encoding='utf-8') as fp_in:
         parser.read_file(fp_in)
 
-    name = parser.get("core", "name", fallback="snowball")
-    core["name"] = name
+    core["name"] = parser.get("core", "name", fallback="snowball")
+    core["db_file"] = parser.get("core", "db_file", fallback="data/snowball.db")
+    core["log_level"] = parser.get("core", "log_level", fallback="WARN").upper()
 
-    level = parser.get("core", "log_level", fallback="WARN").upper()
-    init_logs(name, level)
+    init_logs(core["name"], core["log_level"])
+
     info("configuring services")
     has_service = False
     if "discord" in parser.sections():
@@ -35,3 +35,4 @@ def init(config:str)->(None|Exception):
 
     if not has_service:
         raise ConfigError("no service defined, please add a service to your config")
+

--- a/packages/config/database.py
+++ b/packages/config/database.py
@@ -1,0 +1,62 @@
+"""module to manage database"""
+from logging import debug
+from sqlite3 import connect, Connection, IntegrityError
+class Database(object):
+    """the object to manage the access of the database"""
+    conn:Connection
+
+    def __init__(self, db_file:str):
+        self.conn = connect(db_file)
+        self.__schemas()
+
+    def __schemas(self):
+        """build out the schema for the server data"""
+        servers = '''CREATE TABLE IF NOT EXISTS servers (
+            external_id TEXT UNIQUE NOT NULL,
+            service_type TEXT NOT NULL,
+            count INT NOT NULL DEFAULT 0,
+            count_user TEXT DEFAULT ''
+            );'''
+        cur = self.conn.cursor()
+        cur.execute(servers)
+        self.conn.commit()
+
+    def initialize_server(self, external_id:str, service_type:str):
+        """initiallize a server data store for counting"""
+        insert = """INSERT INTO servers (external_id, service_type)
+        VALUES (?, ?)"""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(insert, (external_id, service_type,))
+            self.conn.commit()
+        except IntegrityError:
+            debug("initializing server already initialized")
+
+    def get_current_count(self, external_id:str):
+        """get the current count for the server"""
+        cur = self.conn.cursor()
+        res = cur.execute(
+            "SELECT count, count_user FROM servers WHERE external_id=?;", 
+            (external_id,))
+        self.conn.commit()
+        return res.fetchone()
+
+    def increment_count(self, external_id:str, user:str, count:int):
+        """set the server count to the given count"""
+        increment = """UPDATE servers
+            SET count = ?,count_user = ?
+            WHERE external_id = ?;"""
+        cur = self.conn.cursor()
+        cur.execute(increment, (count, user, external_id,))
+        self.conn.commit()
+
+    def reset_count(self, external_id:str):
+        """reset the count for the server to zero"""
+        reset = """UPDATE servers
+            SET count = 0,count_user=NULL
+            WHERE external_id = ?"""
+        cur = self.conn.cursor()
+        cur.execute(reset, (external_id,))
+
+
+

--- a/packages/counting/counting.py
+++ b/packages/counting/counting.py
@@ -1,11 +1,17 @@
 """module maaging counting state"""
+from subprocess import run, CalledProcessError
 
-def check_next_count(message:str) -> bool:
-    """check if the message is valid for the next expected count"""
-    return isinstance(message, str)
-
-def increment_count()->None:
-    """update the state of the expected count to the next iteration"""
-
-def reset_count()->None:
-    """reset the state of the expected count back to the beginning"""
+def parse_message(message:str) -> tuple[int, bool]:
+    """parses message and uses linux dc to calculate math"""
+    try:
+        int(message[0])
+    except ValueError:
+        return (-1, False)
+    try:
+        data = run(["dc", "-e", message + " p"], capture_output=True, check=True)
+        count = int(data.stdout)
+        return (count, True)
+    except ValueError:
+        return (-1, True)
+    except CalledProcessError:
+        return (-1, True)

--- a/packages/counting/counting.py
+++ b/packages/counting/counting.py
@@ -1,12 +1,25 @@
 """module maaging counting state"""
 from subprocess import run, CalledProcessError
+from logging import debug
 
 def parse_message(message:str) -> tuple[int, bool]:
-    """parses message and uses linux dc to calculate math"""
+    """parses message and uses linux dc to calculate math
+    returns a tuple of the value and a bool of if the message was countable"""
+
+    # try to see if the number is just a number
+    try:
+        count = int(message)
+        return (count, True)
+    except ValueError:
+        debug("message not wholly integer")
+
+    # check if the first character is a digit if not, return not countable
     try:
         int(message[0])
     except ValueError:
         return (-1, False)
+    
+    # shim out to linux desk calculator to see if message is postfix math
     try:
         data = run(["dc", "-e", message + " p"], capture_output=True, check=True)
         count = int(data.stdout)

--- a/packages/counting/counting.py
+++ b/packages/counting/counting.py
@@ -1,6 +1,7 @@
 """module maaging counting state"""
 from subprocess import run, CalledProcessError
 from logging import debug
+from re import search
 
 def parse_message(message:str) -> tuple[int, bool]:
     """parses message and uses linux dc to calculate math
@@ -18,6 +19,13 @@ def parse_message(message:str) -> tuple[int, bool]:
         int(message[0])
     except ValueError:
         return (-1, False)
+
+    # check to see if there's like text in the message after some math
+    pattern = r"[a-zA-Z]"
+    search_match = search(pattern, message)
+    if search_match is not None:
+        math = message[:search_match.start()]
+        message = math
     
     # shim out to linux desk calculator to see if message is postfix math
     try:

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -61,7 +61,7 @@ I just restarted, your last valid count was {count}"""
                 else:
                     self.db_conn.reset_count(str(message.guild.id))
                     await message.add_reaction('❎')
-                    await message.channel.send('the cycle begins anew (or it would if the reset was hooked in)')
+                    await message.channel.send('the cycle begins anew')
             
             
             

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -51,7 +51,7 @@ I just restarted, your last valid count was {count}"""
                 if this_count == -1:
                     self.db_conn.reset_count(str(message.guild.id))
                     await message.add_reaction('❎')
-                    await message.channel.send('the cycle begins anew (or it would if the reset was hooked in)')
+                    await message.channel.send('the cycle begins anew')
                 elif this_count == count + 1:
                     self.db_conn.increment_count(
                         str(message.guild.id),

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -54,6 +54,9 @@ I just restarted, your last valid count was {count}"""
                 elif this_count == count + 1:
                     await message.add_reaction('✅')
                     await message.channel.send("the count isn't going up yet but it would, congrats!")
+                else:
+                    await message.add_reaction('❎')
+                    await message.channel.send('the cycle begins anew (or it would if the reset was hooked in)')
             self._lock.release()
         else:
             await message.add_reaction('🌨')


### PR DESCRIPTION
## Background

since this is a counter, we gotta store the state, parse the messages and figure out if your count was correct or not

## Changes

* Adds linux `dc` desk calculator to docker container build
* Adds sqlite3 database interface to bot
* Adds message parsing logic
* Adds bot startup logic for helpful messaging
* Adds reaction/messaging on correct/incorrect/duplicate counts

## Links

* 

## This PR makes me feel

![gif of a large snowball being rolled on the ground surrounded by a crowd and quickly being lost control of as it rolls madly on into the crowd](https://media4.giphy.com/media/OyJepPM7SWKcM/giphy.gif?cid=6104955eesfy7sba1oc95v693915z9r2snhtkmca34dy6ywy&ep=v1_gifs_translate&rid=giphy.gif&ct=g)