### PR TITLE
Add high score and command based shutdown

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -5,6 +5,8 @@ services:
       BOT_LOG_LEVEL: INFO
       BOT_DATABASE: data/snowball.db
       BOT_DISCORD_CHANNEL: approved-channel
+      BOT_DISCORD_ADMIN_GUILD: id-for-admin-server
+      BOT_DISCORD_ADMIN_ROLE: id-for-admin-role
       BOT_DISCORD_APP_KEY: app-id
       BOT_DISCORD_PUBLIC_KEY: public-key
       BOT_DISCORD_TOKEN: sdk.token

--- a/packages/config/config.py
+++ b/packages/config/config.py
@@ -20,6 +20,8 @@ def init()->(Configs|Exception):
     parser.bind("name")
     parser.bind("database")
     parser.bind("log_level")
+    parser.bind("admin_guild", "discord")
+    parser.bind("admin_role", "discord")
     parser.bind("channel", "discord")
     parser.bind("app_key", "discord")
     parser.bind("public_key", "discord")

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -32,22 +32,28 @@ I just restarted, your last valid count was {count}"""
                     await channel.send(msg)
 
     async def __check_commands(self, message:Message)->bool:
+        # TODO: Move these to a command subsystem to call functions on match.
         commands = {
             "!commands": "",
             "!help":  help_string,
-            "!highscore":  f"Your server highscore is: {self.db_conn.get_highscore(str(message.guild.id))}"
-            
+            "!highscore": "Your server highscore is:"
         }
+
         # this has to be done outside of the dict initialzation
         commands["!commands"] = "\n".join(commands.keys())
-       
+
+        # Check if is shutdown command, and if so, if allowed to shutdown
         if message.content.startswith("!shutdown"):
-                await self.__shutdown(message)
-                return True
+            await self.__shutdown(message)
+            return True
+
+        # check if known command
         reply = commands.get(message.content)
         if reply is not None:
+            # TODO: wrap highscore in its own function that only would get called if match.
+            if reply.startswith("Your server"):
+                reply = reply +  self.db_conn.get_highscore(str(message.guild.id))
             await message.reply(reply)
-            
             return True
         return False
 
@@ -58,7 +64,7 @@ I just restarted, your last valid count was {count}"""
 
         if message.author.id == self.user.id:
             return
-        
+
         if await self.__check_commands(message):
             return
 

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -1,5 +1,6 @@
 """module managing connecting to the discord api"""
 import logging
+from time import sleep
 from multiprocessing import Lock
 from discord import Client, Intents, Message
 from packages.config.database import Database
@@ -34,14 +35,19 @@ I just restarted, your last valid count was {count}"""
         commands = {
             "!commands": "",
             "!help":  help_string,
-            "!highscore":  "high score is not implemented yet"
+            "!highscore":  f"Your server highscore is: {self.db_conn.get_highscore(str(message.guild.id))}"
+            
         }
         # this has to be done outside of the dict initialzation
         commands["!commands"] = "\n".join(commands.keys())
        
+        if message.content.startswith("!shutdown"):
+                await self.__shutdown(message)
+                return True
         reply = commands.get(message.content)
         if reply is not None:
             await message.reply(reply)
+            
             return True
         return False
 
@@ -84,6 +90,14 @@ I just restarted, your last valid count was {count}"""
             self._lock.release()
         else:
             await message.add_reaction('🌨')
+
+    async def __shutdown(self, message:Message):
+        if message.guild.id == int(self.configs.get("admin_guild", "discord")):
+            for role in message.author.roles:
+                if int(self.configs.get("admin_role", "discord")) == role.id:
+                    await message.channel.send(f"{self.configs.get('name')} is shutting down")
+                    sleep(2)
+                    raise KeyboardInterrupt
 
 def run(configs)->None:
     """creates a new discord client"""


### PR DESCRIPTION
## Background

This pulled in two issues, the highscore and the shutdown admin command.


## Changes

* Adds high score to the database table and `!highscore` command for pulling server's highscore.
* Adds `!shutdown` command locked to admin role in admin server to notify before bot shutdown

## Links

* https://github.com/erindatkinson/snowball/issues/10
* https://github.com/erindatkinson/snowball/issues/4

## This PR makes me feel

highscoring

![](https://media4.giphy.com/media/f7k9IGj6kymysVxkWt/giphy-downsized.gif?cid=6104955e747mjvgwffx2hx01h6vn7vhok49jym1j4x8erhx2&ep=v1_gifs_translate&rid=giphy-downsized.gif&ct=g)