### PR TITLE
[Fix] Use correct highscore column, add custom emoji

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -5,6 +5,7 @@ services:
       BOT_LOG_LEVEL: INFO
       BOT_DATABASE: data/snowball.db
       BOT_DISCORD_CHANNEL: approved-channel
+      BOT_DISCORD_RESET_EMOJI: negative_squared_cross_mark
       BOT_DISCORD_ADMIN_GUILD: id-for-admin-server
       BOT_DISCORD_ADMIN_ROLE: id-for-admin-role
       BOT_DISCORD_APP_KEY: app-id

--- a/packages/config/config.py
+++ b/packages/config/config.py
@@ -26,6 +26,7 @@ def init()->(Configs|Exception):
     parser.bind("app_key", "discord")
     parser.bind("public_key", "discord")
     parser.bind("token", "discord")
+    parser.bind("reset_emoji", "discord")
     data = parser.parse()
     configs = Configs(data)
     init_logs(configs.get("name"), configs.get("log_level"))

--- a/packages/config/database.py
+++ b/packages/config/database.py
@@ -47,7 +47,7 @@ class Database:
         query = """UPDATE servers
             SET count = ?,
             count_user = ?,
-            highscore = CASE WHEN high_score < ? THEN ? ELSE highs_core END
+            high_score = CASE WHEN high_score < ? THEN ? ELSE high_score END
             WHERE external_id = ?;"""
         with closing(self.conn.cursor()) as cur:
             cur.execute(query, (count, user, count, count, external_id, ))


### PR DESCRIPTION
## Background

Had a few typos `highscore` instead of `high_score`, and `highs_core` instead of `high_score`
Also adding custom emoji to prepend in front of reset string.

## Changes

* Fixes db query for updating current count
* Adds custom emoji environment variable to prepend in front of the reset message.

## Links

* https://github.com/erindatkinson/snowball/issues/8 

## This PR makes me feel

oops

![](https://media4.giphy.com/media/mvyvXwL26FfAtRCLPk/giphy.gif?cid=ecf05e47gvr7inh7grgn9h2dc629kh89f8amp5mk88w73tdx&ep=v1_gifs_search&rid=giphy.gif&ct=g)