### PR TITLE
Update error handling inside acquired lock block

### DIFF
--- a/packages/counting/counting.py
+++ b/packages/counting/counting.py
@@ -3,10 +3,13 @@ from subprocess import run, CalledProcessError
 from logging import debug
 from re import search
 
-def parse_message(message:str) -> tuple[int, bool]:
+
+def parse_message(message: str) -> tuple[int, bool]:
     """parses message and uses linux dc to calculate math
     returns a tuple of the value and a bool of if the message was countable"""
-
+    # no message means no counting.
+    if len(message) == 0:
+        return -1, False
     # try to see if the number is just a number
     try:
         count = int(message)
@@ -25,7 +28,7 @@ def parse_message(message:str) -> tuple[int, bool]:
     pattern = r"[a-zA-Z]"
     search_match = search(pattern, message)
     if search_match is not None:
-        math = message[:search_match.start()]
+        math = message[: search_match.start()]
         message = math
 
     # shim out to linux desk calculator to see if message is postfix math


### PR DESCRIPTION
## Background

Per #21 the bot will fail to release the lock on exceptions, and an exception would consistently happen on an empty message (ie. a message is sent with only an attached image or a sticker.

## Changes

* Wrap the on message checks inside the acquired lock block in try/except/finally so that:
    * A) lock is guaranteed to be released
    * B) exceptions are logged better
* Update the message parsing function to short circuit parsing on an empty message to stop the exception from happening.  

## Links

* #21 

## This PR makes me feel

#gated

![image of a gate opening and closing](https://github.com/erindatkinson/snowball/assets/20285458/b40f5b58-a57a-4bcf-beae-73dae160e0bb)

