### PR TITLE
Move commands to functions, add !status command

### DIFF
--- a/packages/config/logging.py
+++ b/packages/config/logging.py
@@ -1,11 +1,13 @@
 """module to manage logging"""
+
 from logging import Formatter, StreamHandler, getLevelNamesMapping, basicConfig
 from typing import Any
 from sys import stdout
 
-log:dict[str, Any] = {}
+log: dict[str, Any] = {}
 
-def init_logs(name:str, level:str)->None:
+
+def init_logs(name: str, level: str) -> None:
     """initialize the default logger and the global bits"""
     log["formatter"] = Formatter(f"{name} [%(levelname)s] - %(message)s")
     log["level"] = getLevelNamesMapping()[level]

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -90,7 +90,6 @@ I just restarted, your last valid count was {count}"""
                 count, user = self.db_conn.get_current_count(str(message.guild.name))
                 this_count, countable = parse_message(message.content)
                 if not countable:
-                    self._lock.release()
                     return
                 if user == str(message.author.id):
                     await message.add_reaction("🎭")

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -6,6 +6,7 @@ from discord import Client, Intents, Message
 from packages.config.database import Database
 from packages.counting.counting import parse_message
 from packages.templates.help import help_string, status_string
+from packages.templates.reset import reset_string
 
 
 class DiscordClient(Client):
@@ -98,7 +99,11 @@ I just restarted, your last valid count was {count}"""
                     await message.add_reaction("❎")
 
                     await message.channel.send(
-                        f"{self.emoji_string} The cycle begins anew"
+                        reset_string.format(
+                            count=count,
+                            this_count=this_count,
+                            emoji_string=self.emoji_string,
+                        )
                     )
                 elif this_count == count + 1:
                     self.db_conn.increment_count(
@@ -109,7 +114,11 @@ I just restarted, your last valid count was {count}"""
                     self.db_conn.reset_count(str(message.guild.name))
                     await message.add_reaction("❎")
                     await message.channel.send(
-                        f"{self.emoji_string} The cycle begins anew"
+                        reset_string.format(
+                            count=count,
+                            this_count=this_count,
+                            emoji_string=self.emoji_string,
+                        )
                     )
             self._lock.release()
         else:

--- a/packages/templates/help.py
+++ b/packages/templates/help.py
@@ -22,3 +22,6 @@ are as follows: if the expected number is 32, you would be able to write `2 3 ^ 
 to 2^3 * 4 with infix notation), or if the expected number is 1, you could write `_3 _3 * 16 2 / -` (which
 would be like writing `( -3 * -3 ) - ( 16 / 2 )` with infix)
 """
+
+status_string = """The last valid count was {count}
+The server highscore is: {highscore}"""

--- a/packages/templates/reset.py
+++ b/packages/templates/reset.py
@@ -1,4 +1,4 @@
 """module for reset templates"""
 
 reset_string = """{emoji_string} The cycle begins anew.
-The correct count was {count} but I recieved {this_count}"""
+The correct count was {count} but I received {this_count}"""

--- a/packages/templates/reset.py
+++ b/packages/templates/reset.py
@@ -1,0 +1,4 @@
+"""module for reset templates"""
+
+reset_string = """{emoji_string} The cycle begins anew.
+The correct count was {count} but I recieved {this_count}"""


### PR DESCRIPTION
## Background

Per the background of #20, it'd be nice to have a status command for when a lot of postfix math has been thrown around.
Additionally, the status of an incorrect guess being added to the reset message helps in debugging.

## Changes

* Update command list values to be methods with the signature `fn (self, guild:str) -> str` 
* Add !status command
* Update reset string to include status of incorrect guess

example !status command response

```text
The last valid count was 23
The server highscore is: 6437
``` 

example reset response

```text
:bufobackpat: The cycle begins anew.
The correct count was 37 but I received 23
```

## Links

* #20
* #24 

## This PR makes me feel

![gif of jean luc picard standing from the captains chair and saying the word report, the word is also at the bottom of the image](https://github.com/erindatkinson/snowball/assets/20285458/707454c2-e50f-49e6-8720-b5f73bc79a03)
