### PR TITLE
Add lock buffer and bugfixes

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -11,3 +11,4 @@ services:
       BOT_DISCORD_APP_KEY: app-id
       BOT_DISCORD_PUBLIC_KEY: public-key
       BOT_DISCORD_TOKEN: sdk.token
+      BOT_DISCORD_MUTEX_HOLD: 2

--- a/packages/config/config.py
+++ b/packages/config/config.py
@@ -3,18 +3,21 @@
 from packages.expectenv.expectenv import ExpectEnvParser
 from .logging import init_logs
 
+
 class Configs:
     """class to manage the various configs for the app"""
+
     def __init__(self, configs):
         self.configs = configs
 
-    def get(self, key, namespace=None)->str:
+    def get(self, key, namespace=None) -> str:
         """get pulls a key from a namespace or raises a KeyError if not found"""
         if namespace is None:
             return self.configs["core"][key]
         return self.configs[namespace][key]
 
-def init()->(Configs|Exception):
+
+def init() -> Configs | Exception:
     """initializes the configuration for the bot"""
     parser = ExpectEnvParser("bot")
     parser.bind("name")
@@ -27,6 +30,7 @@ def init()->(Configs|Exception):
     parser.bind("public_key", "discord")
     parser.bind("token", "discord")
     parser.bind("reset_emoji", "discord")
+    parser.bind("mutex_hold", "discord")
     data = parser.parse()
     configs = Configs(data)
     init_logs(configs.get("name"), configs.get("log_level"))

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -100,7 +100,7 @@ I just restarted, your last valid count was {count}"""
                         await message.add_reaction("❎")
                         await message.channel.send(
                             reset_string.format(
-                                count=count,
+                                count=count + 1,
                                 this_count=this_count,
                                 emoji_string=self.emoji_string,
                             )
@@ -115,7 +115,7 @@ I just restarted, your last valid count was {count}"""
                         await message.add_reaction("❎")
                         await message.channel.send(
                             reset_string.format(
-                                count=count,
+                                count=count + 1,
                                 this_count=this_count,
                                 emoji_string=self.emoji_string,
                             )
@@ -123,6 +123,7 @@ I just restarted, your last valid count was {count}"""
             except Exception as e:
                 logging.error(e)
             finally:
+                sleep(2)
                 self._lock.release()
         else:
             await message.add_reaction("🌨")

--- a/packages/services/discord.py
+++ b/packages/services/discord.py
@@ -123,7 +123,7 @@ I just restarted, your last valid count was {count}"""
             except Exception as e:
                 logging.error(e)
             finally:
-                sleep(2)
+                sleep(float(self.configs.get("mutex_hold", "discord")))
                 self._lock.release()
         else:
             await message.add_reaction("🌨")


### PR DESCRIPTION
## Background

We had already known, per #22, that there was some issues with the lock being "not long enough" and having times that reasonably should be marked as 🌨 were instead being marked as incorrect.

## Changes

* Updated the locked block to sleep for a configurable number of seconds after parsing to ensure that close guesses 
* Updated template variable to print expected number correctly

## Links

* #22 

## This PR makes me feel

![locked](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDE5NWxjOXFyMTVnbjFnbmRiaDdqNmwxM2Nva29seDY1cGRmMXdlYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zxnBe1tqyFRGPhD4oe/giphy.gif)